### PR TITLE
Update to traefik v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,10 @@ You must include a `.env` file with the following content:
 SMR_CONFIG_DIR=/path/to/config/dir
 SMR_UPLOAD_DIR=/path/to/upload/dir
 ```
+
+For using Let's Encrypt, you need to create an empty file in the traefik
+subdirectory as follows:
+```
+touch traefik/acme.json
+chmod 600 traefik/acme.json
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,11 +22,8 @@ services:
             - ./player-upload:/smr/htdocs/upload:rw
         labels:
             - "traefik.enable=true"
-            - "traefik.docker.network=frontend"
-            - "traefik.backend=smr"
-            - "traefik.frontend.passHostHeader=true"
-            - "traefik.frontend.rule=Host:www.smrealms.de;PathPrefix:/"
-            - "traefik.port=80"
+            - "traefik.http.routers.smr-game.rule=Host(`www.smrealms.de`, `smrealms.de`) && PathPrefix(`/`)"
+            - "traefik.http.routers.smr-game.middlewares=nonwww-to-www@file"
         depends_on:
             - smtp
             - mysql
@@ -41,8 +38,6 @@ services:
         environment:
             - POSTFIX_myhostname=einstein.fem.tu-ilmenau.de
             - OPENDKIM_DOMAINS=smrealms.de=key1
-        labels:
-            - "traefik.enable=false"
         volumes:
             - ./opendkim:/etc/opendkim/keys/smrealms.de
 
@@ -61,8 +56,6 @@ services:
             MYSQL_DATABASE:      smr_live
         volumes:
             - ./data/db:/var/lib/mysql
-        labels:
-            - "traefik.enable=false"
         # The mysql:5.7+ docker default sql mode uses STRICT_TRANS_TABLES,
         # which is incompatible with the way the SMR database is used.
         # Therefore, we override CMD to omit this sql mode.
@@ -75,8 +68,6 @@ services:
         command: -url=jdbc:mysql://${MYSQL_HOST}/smr_live?useSSL=false -user=smr -password=${MYSQL_PASSWORD} migrate
         networks:
             - backend
-        labels:
-            - "traefik.enable=false"
         depends_on:
             - mysql
 
@@ -87,8 +78,6 @@ services:
             - backend
         volumes:
             - ./config:/smr/config:ro
-        labels:
-            - "traefik.enable=false"
         depends_on:
             - mysql
 
@@ -99,8 +88,6 @@ services:
             - backend
         volumes:
             - ./config:/smr/config:ro
-        labels:
-            - "traefik.enable=false"
         depends_on:
             - mysql
 
@@ -111,8 +98,6 @@ services:
             - backend
         volumes:
             - ./config:/smr/config:ro
-        labels:
-            - "traefik.enable=false"
         depends_on:
             - mysql
             - smtp
@@ -126,14 +111,11 @@ services:
             - backend
         environment:
             PMA_HOST: ${MYSQL_HOST}
-            PMA_ABSOLUTE_URI: https://www.smrealms.de/pma/
+            PMA_ABSOLUTE_URI: /pma/
         labels:
             - "traefik.enable=true"
-            - "traefik.docker.network=frontend"
-            - "traefik.backend=smr-phpmyadmin"
-            - "traefik.frontend.passHostHeader=true"
-            - "traefik.frontend.rule=Host:www.smrealms.de;PathPrefixStrip:/pma/"
-            - "traefik.port=80"
+            - "traefik.http.routers.smr-pma.rule=Host(`www.smrealms.de`, `smrealms.de`) && PathPrefix(`/pma`)"
+            - "traefik.http.routers.smr-pma.middlewares=slash-then-strip@file"
         depends_on:
             - mysql
             - traefik
@@ -145,31 +127,24 @@ services:
             - frontend
         labels:
             - "traefik.enable=true"
-            - "traefik.docker.network=frontend"
-            - "traefik.backend=api-docs"
-            - "traefik.port=80"
-            - "traefik.frontend.rule=Host:api.smrealms.de"
+            - "traefik.http.routers.smr-api.rule=Host(`api.smrealms.de`)"
         depends_on:
             - traefik
 
     traefik:
-        image: traefik:1.7
+        image: traefik:2.2
         restart: unless-stopped
         container_name: smr-traefik
         networks:
             - frontend
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock
-            - ./traefik/acme.json:/acme/acme.json
-            - ./traefik/traefik.toml:/etc/traefik/traefik.toml
+            - ./traefik:/etc/traefik
         labels:
             - "traefik.enable=true"
-            - "traefik.backend=traefik-dashboard"
-            - "traefik.docker.network=frontend"
-            - "traefik.frontend.passHostHeader=true"
-            - "traefik.frontend.rule=PathPrefixStrip:/traefik"
+            - "traefik.http.routers.traefik.rule=Host(`traefik.smrealms.de`)"
+            - "traefik.http.routers.traefik.service=api@internal"
             - "traefik.frontend.auth.basic.users=traefik:$$apr1$$N1XTczE5$$5GvS93f.oSRstkxmjw9JD0"
-            - "traefik.port=8080"
         ports:
             - "80:80"
             - "443:443"

--- a/traefik/file-provider.toml
+++ b/traefik/file-provider.toml
@@ -1,0 +1,16 @@
+[http.middlewares]
+  # For services that need to strip off a PathPrefix and/or add a trailing slash
+  [http.middlewares.strip-pathprefix.stripPrefixRegex]
+    regex = ["/[^/]+"]
+  [http.middlewares.add-slash.redirectRegex]
+    regex = "^(https?://[^/]+/[^/]+)$"
+    replacement = "${1}/"
+    permanent = true
+  [http.middlewares.slash-then-strip.chain]
+    middlewares = ["add-slash", "strip-pathprefix"]
+
+  # Canonicalize non-www to www
+  [http.middlewares.nonwww-to-www.redirectRegex]
+    regex = "^https://smrealms.de/(.*)"
+    replacement = "https://www.smrealms.de/$1"
+    permanent = true

--- a/traefik/traefik.toml
+++ b/traefik/traefik.toml
@@ -1,51 +1,36 @@
-logLevel = "INFO"
-
-defaultEntryPoints = ["http","https"]
-
 [entryPoints]
 
   [entryPoints.http]
     address = ":80"
 
-    [entryPoints.http.redirect]
-      entryPoint = "https"
+    [entryPoints.http.http.redirections.entryPoint]
+      to = "https"
+      scheme = "https"
+      permanent = true
 
   [entryPoints.https]
     address = ":443"
 
-    [entryPoints.https.redirect]
-    # Canonicalize non-www to www
-    regex = "^https://smrealms.de/(.*)"
-    replacement = "https://www.smrealms.de/$1"
-    permanent = true
+    [entryPoints.https.http.tls]
+      certResolver = "myresolver"
 
-    [entryPoints.https.tls]
+[providers]
+  [providers.docker]
+    exposedByDefault = false
+    network = "frontend"
+  [providers.file]
+    filename = "/etc/traefik/file-provider.toml"
 
-# We need this for the /traefik/dashboard to work
+# We need this for the traefik dashboard to work
 [api]
 
-[acme]
+[certificatesResolvers.myresolver.acme]
   email = "mrspock@smrealms.de"
-  storage = "/acme/acme.json"
+  storage = "/etc/traefik/acme.json"
   caServer = "https://acme-v02.api.letsencrypt.org/directory"
-  acmeLogging = true
-  entryPoint = "https"
+  [certificatesResolvers.myresolver.acme.tlsChallenge]
 
-  [acme.tlsChallenge]
-
-[[acme.domains]]
-  main = "smrealms.de"
-  sans = ["www.smrealms.de", "api.smrealms.de", "wiki.smrealms.de",
-          "beta.smrealms.de", "smrcnn.smrealms.de"]
-#[[acme.domains]]
-#  main = "smrealms.com"
-#  sans = ["www.smrealms.com"]
-[[acme.domains]]
-  main = "einstein.fem.tu-ilmenau.de"
-
-[docker]
-  exposedByDefault = false
-
-[traefikLog]
+[log]
+  level = "INFO"
 
 [accessLog]


### PR DESCRIPTION
See smrealms/smr#889 for main details about the migration, as the
config is mostly copied from there.

Additional notes specific to the live server:

* The smrealms.de -> www.smrealms.de canonicalization now happens at
  the middleware level for a specific router (in this case `smr-game`)
  instead of at the entrypoint level. As such, `smr-game` now needs
  to be routed to from both Host addresses.

* Switch the traefik service location from www.smrealms.de/traefik to
  traefik.smrealms.de. This makes routing easier, since the traefik v2
  dashboard does not yet support generic path prefixes.

* Switch to a domain-agnostic `PMA_ABSOLUTE_URI` for phpMyAdmin, as we
  do in the development pma service.

* The TLS/ACME syntax has changed significantly. The certificates are
  generated automatically by the certificatesResolvers when a router
  using the resolver specifies a `Host` rule. We attach the resolver
  to the https entrypoint as a convenience to set the resolver for all
  of our routers.