### PR TITLE
docker-compose.yml: update image for CLI programs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,18 @@ networks:
       name: backend
       external: false
 
+# Base configuration for the SMR command line tools
+x-smr-cli: &smr-cli
+    image: smrealms/smr:cli
+    networks:
+        - backend
+    volumes:
+        - ./config:/smr/config:ro
+        - ./.env:/smr/.env:ro
+    depends_on:
+        - mysql
+        - smtp
+
 services:
 
     smr:
@@ -73,38 +85,19 @@ services:
             - mysql
 
     discord:
-        image: smrealms/smr:discordbot
+        command: php discord/bot.php
         restart: unless-stopped
-        networks:
-            - backend
-        volumes:
-            - ./config:/smr/config:ro
-            - ./.env:/smr/.env:ro
-        depends_on:
-            - mysql
+        <<: *smr-cli
 
     irc:
-        image: smrealms/smr:ircbot
+        command: php irc/irc.php
         restart: unless-stopped
-        networks:
-            - backend
-        volumes:
-            - ./config:/smr/config:ro
-            - ./.env:/smr/.env:ro
-        depends_on:
-            - mysql
+        <<: *smr-cli
 
     npc:
-        image: smrealms/smr:npc
+        command: php npc/npc.php
         restart: "no"
-        networks:
-            - backend
-        volumes:
-            - ./config:/smr/config:ro
-            - ./.env:/smr/.env:ro
-        depends_on:
-            - mysql
-            - smtp
+        <<: *smr-cli
 
     pma:
         image: phpmyadmin/phpmyadmin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ networks:
 
 # Base configuration for the SMR command line tools
 x-smr-cli: &smr-cli
-    image: smrealms/smr:cli
+    image: smrealms/smr:web
     networks:
         - backend
     volumes:
@@ -85,17 +85,17 @@ services:
             - mysql
 
     discord:
-        command: php discord/bot.php
+        command: php tools/discord/bot.php
         restart: unless-stopped
         <<: *smr-cli
 
     irc:
-        command: php irc/irc.php
+        command: php tools/irc/irc.php
         restart: unless-stopped
         <<: *smr-cli
 
     npc:
-        command: php npc/npc.php
+        command: php tools/npc/npc.php
         restart: "no"
         <<: *smr-cli
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
         volumes:
             - ./config:/smr/config:ro
             - ./.env:/smr/.env:ro
-            - ./player-upload:/smr/htdocs/upload:rw
+            - ./player-upload:/smr/src/htdocs/upload:rw
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.smr-game.rule=Host(`www.smrealms.de`, `smrealms.de`) && PathPrefix(`/`)"
@@ -85,17 +85,17 @@ services:
             - mysql
 
     discord:
-        command: php tools/discord/bot.php
+        command: php src/tools/discord/bot.php
         restart: unless-stopped
         <<: *smr-cli
 
     irc:
-        command: php tools/irc/irc.php
+        command: php src/tools/irc/irc.php
         restart: unless-stopped
         <<: *smr-cli
 
     npc:
-        command: php tools/npc/npc.php
+        command: php src/tools/npc/npc.php
         restart: "no"
         <<: *smr-cli
 


### PR DESCRIPTION
The npc, discordbot, and ircbot image variants have been replaced by
a single cli image variant. See smrealms/smr#943.

Deferred until the `smr-cli` image is built on DockerHub (and after the referenced PR is pushed to the `live` branch).